### PR TITLE
fix: 解析登录响应、修复 Shell URL 编码、新增日志轮转

### DIFF
--- a/nodejs/index.js
+++ b/nodejs/index.js
@@ -459,7 +459,9 @@ function rotateLogIfNeeded(logFile, maxSize = DEFAULT_MAX_LOG_SIZE) {
   try {
     const stat = fs.statSync(logFile);
     if (stat.size >= maxSize) {
-      fs.renameSync(logFile, `${logFile}.1`);
+      const rotatedLogFile = `${logFile}.1`;
+      fs.rmSync(rotatedLogFile, { force: true });
+      fs.renameSync(logFile, rotatedLogFile);
       fs.writeFileSync(logFile, "");
     }
   } catch {

--- a/nodejs/index.js
+++ b/nodejs/index.js
@@ -420,6 +420,7 @@ function createLogger(state) {
       clearHeartbeat(state.logToStdout);
       console.log(styleLogLine(currentTimestamp, message));
     }
+    rotateLogIfNeeded(state.logFile);
     fs.appendFileSync(state.logFile, `${line}\n`, "utf8");
   };
 }
@@ -427,6 +428,35 @@ function createLogger(state) {
 function getUserAccount(config) {
   const suffix = netSuffixMap[config.TYPE] ?? "";
   return suffix ? `${config.USERNAME}@${suffix}` : config.USERNAME;
+}
+
+function parseLoginResponse(text) {
+  if (!text) {
+    return { success: false, message: "" };
+  }
+  try {
+    const data = JSON.parse(text);
+    if (data.result === 1 || data.result === "1") {
+      return { success: true, message: data.msg || "Login successful" };
+    }
+    return { success: false, message: data.msg || text };
+  } catch {
+    return { success: false, message: text };
+  }
+}
+
+const DEFAULT_MAX_LOG_SIZE = 5 * 1024 * 1024;
+
+function rotateLogIfNeeded(logFile, maxSize = DEFAULT_MAX_LOG_SIZE) {
+  try {
+    const stat = fs.statSync(logFile);
+    if (stat.size >= maxSize) {
+      fs.renameSync(logFile, `${logFile}.1`);
+      fs.writeFileSync(logFile, "");
+    }
+  } catch {
+    // file may not exist yet
+  }
 }
 
 function runCurl(args) {
@@ -497,14 +527,16 @@ async function login(config, log) {
   ]);
 
   if (curlResult.ok) {
-    log(`Login response: ${curlResult.stdout.trim()}`);
+    const parsed = parseLoginResponse(curlResult.stdout.trim());
+    log(parsed.success ? `Login successful: ${parsed.message}` : `Login failed: ${parsed.message}`);
     return;
   }
 
   if (curlResult.stdout || curlResult.stderr) {
     const curlMessage = `${curlResult.stdout}${curlResult.stderr}`.trim();
     if (curlMessage) {
-      log(`Login response: ${curlMessage}`);
+      const parsed = parseLoginResponse(curlMessage);
+      log(parsed.success ? `Login successful: ${parsed.message}` : `Login failed: ${parsed.message}`);
       return;
     }
   }
@@ -518,9 +550,10 @@ async function login(config, log) {
       signal: AbortSignal.timeout(5000)
     });
     const text = await response.text();
-    log(`Login response: ${text}`);
+    const parsed = parseLoginResponse(text);
+    log(parsed.success ? `Login successful: ${parsed.message}` : `Login failed: ${parsed.message}`);
   } catch (error) {
-    log(`Login response: ${error.message}`);
+    log(`Login failed: ${error.message}`);
   }
 }
 
@@ -627,5 +660,7 @@ if (require.main === module) {
 
 module.exports = {
   main,
-  run
+  run,
+  parseLoginResponse,
+  rotateLogIfNeeded
 };

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -32,7 +32,8 @@
     "README.md"
   ],
   "scripts": {
-    "start": "node index.js"
+    "start": "node index.js",
+    "test": "node --test test/*.test.js"
   },
   "engines": {
     "node": ">=18"

--- a/nodejs/test/log-rotation.test.js
+++ b/nodejs/test/log-rotation.test.js
@@ -1,0 +1,58 @@
+"use strict";
+
+const { describe, it, before, after } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { rotateLogIfNeeded } = require("../index.js");
+
+describe("rotateLogIfNeeded", () => {
+  let tmpDir;
+  let logFile;
+
+  before(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "csu-log-test-"));
+    logFile = path.join(tmpDir, "test.log");
+  });
+
+  after(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("文件未超阈值时不轮转", () => {
+    fs.writeFileSync(logFile, "small content");
+    rotateLogIfNeeded(logFile, 1024 * 1024);
+    assert.ok(fs.existsSync(logFile));
+    assert.ok(!fs.existsSync(`${logFile}.1`));
+    assert.equal(fs.readFileSync(logFile, "utf8"), "small content");
+  });
+
+  it("文件超过阈值时轮转为 .1", () => {
+    const bigContent = "x".repeat(100);
+    fs.writeFileSync(logFile, bigContent);
+    rotateLogIfNeeded(logFile, 50);
+    assert.ok(fs.existsSync(`${logFile}.1`));
+    assert.equal(fs.readFileSync(`${logFile}.1`, "utf8"), bigContent);
+  });
+
+  it("轮转后原日志文件为空", () => {
+    const bigContent = "x".repeat(100);
+    fs.writeFileSync(logFile, bigContent);
+    rotateLogIfNeeded(logFile, 50);
+    assert.equal(fs.readFileSync(logFile, "utf8"), "");
+  });
+
+  it("已存在 .1 文件时轮转会覆盖它", () => {
+    fs.writeFileSync(`${logFile}.1`, "old rotated content");
+    const bigContent = "y".repeat(100);
+    fs.writeFileSync(logFile, bigContent);
+    rotateLogIfNeeded(logFile, 50);
+    assert.equal(fs.readFileSync(`${logFile}.1`, "utf8"), bigContent);
+  });
+
+  it("日志文件不存在时不抛出异常", () => {
+    const nonExistent = path.join(tmpDir, "nonexistent.log");
+    assert.doesNotThrow(() => rotateLogIfNeeded(nonExistent, 50));
+  });
+});

--- a/nodejs/test/login-response.test.js
+++ b/nodejs/test/login-response.test.js
@@ -1,0 +1,41 @@
+"use strict";
+
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const { parseLoginResponse } = require("../index.js");
+
+describe("parseLoginResponse", () => {
+  it("result=1 时报告成功", () => {
+    const r = parseLoginResponse('{"result":1,"msg":"认证成功"}');
+    assert.equal(r.success, true);
+  });
+
+  it("result=1 时消息包含服务端 msg 字段", () => {
+    const r = parseLoginResponse('{"result":1,"msg":"Authentication success"}');
+    assert.equal(r.success, true);
+    assert.ok(r.message.includes("Authentication success"));
+  });
+
+  it("result=0 时报告失败并携带 msg", () => {
+    const r = parseLoginResponse('{"result":0,"msg":"用户名或密码错误"}');
+    assert.equal(r.success, false);
+    assert.ok(r.message.includes("用户名或密码错误"));
+  });
+
+  it("result=0 且无 msg 时失败消息不为空", () => {
+    const r = parseLoginResponse('{"result":0}');
+    assert.equal(r.success, false);
+    assert.ok(r.message.length > 0);
+  });
+
+  it("非 JSON 响应时原样返回文本并标记失败", () => {
+    const r = parseLoginResponse("some raw portal text");
+    assert.equal(r.success, false);
+    assert.ok(r.message.includes("some raw portal text"));
+  });
+
+  it("空字符串时标记失败", () => {
+    const r = parseLoginResponse("");
+    assert.equal(r.success, false);
+  });
+});

--- a/openwrt/csu-autoauth.sh
+++ b/openwrt/csu-autoauth.sh
@@ -76,36 +76,38 @@ login() {
     URL="https://10.1.1.1:802/eportal/portal/login"
     log "Authenticating as: $USER_ACCOUNT"
     response=$(curl -k -fsS -G "$URL" \
-        -d "user_account=$USER_ACCOUNT" \
-        -d "user_password=$PASSWORD" 2>&1 || true)
+        --data-urlencode "user_account=$USER_ACCOUNT" \
+        --data-urlencode "user_password=$PASSWORD" 2>&1 || true)
     log "Login response: $response"
 }
 
-init_log_file
-load_config || {
-    log "Failed to load UCI config: /etc/config/csu-autoauth"
-    exit 1
-}
-validate_config || exit 1
-log "Start monitoring network status (every ${INTERVAL}s)..."
+if [ "${CSU_TESTING:-0}" = "0" ]; then
+    init_log_file
+    load_config || {
+        log "Failed to load UCI config: /etc/config/csu-autoauth"
+        exit 1
+    }
+    validate_config || exit 1
+    log "Start monitoring network status (every ${INTERVAL}s)..."
 
-LAST_STATUS=""
+    LAST_STATUS=""
 
-while true; do
-    if is_online; then
-        CURRENT_STATUS="up"
-        if [ "$LAST_STATUS" != "$CURRENT_STATUS" ]; then
-            log "Network up"
-            LAST_STATUS="$CURRENT_STATUS"
+    while true; do
+        if is_online; then
+            CURRENT_STATUS="up"
+            if [ "$LAST_STATUS" != "$CURRENT_STATUS" ]; then
+                log "Network up"
+                LAST_STATUS="$CURRENT_STATUS"
+            fi
+        else
+            CURRENT_STATUS="down"
+            if [ "$LAST_STATUS" != "$CURRENT_STATUS" ]; then
+                log "Network down"
+                LAST_STATUS="$CURRENT_STATUS"
+            fi
+            log "Triggering authentication..."
+            login
         fi
-    else
-        CURRENT_STATUS="down"
-        if [ "$LAST_STATUS" != "$CURRENT_STATUS" ]; then
-            log "Network down"
-            LAST_STATUS="$CURRENT_STATUS"
-        fi
-        log "Triggering authentication..."
-        login
-    fi
-    sleep "$INTERVAL"
-done
+        sleep "$INTERVAL"
+    done
+fi

--- a/shell/common/csu-autoauth.sh
+++ b/shell/common/csu-autoauth.sh
@@ -76,32 +76,34 @@ login() {
     URL="https://10.1.1.1:802/eportal/portal/login"
     log "Authenticating as: $USER_ACCOUNT"
     response=$(curl -k -fsS -G "$URL" \
-        -d "user_account=$USER_ACCOUNT" \
-        -d "user_password=$PASSWORD" 2>&1 || true)
+        --data-urlencode "user_account=$USER_ACCOUNT" \
+        --data-urlencode "user_password=$PASSWORD" 2>&1 || true)
     log "Login response: $response"
 }
 
-validate_config
-init_log_file
-log "Start monitoring network status (every ${INTERVAL}s)..."
+if [ "${CSU_TESTING:-0}" = "0" ]; then
+    validate_config
+    init_log_file
+    log "Start monitoring network status (every ${INTERVAL}s)..."
 
-LAST_STATUS=""
+    LAST_STATUS=""
 
-while true; do
-    if is_online; then
-        CURRENT_STATUS="up"
-        if [ "$LAST_STATUS" != "$CURRENT_STATUS" ]; then
-            log "Network up"
-            LAST_STATUS="$CURRENT_STATUS"
+    while true; do
+        if is_online; then
+            CURRENT_STATUS="up"
+            if [ "$LAST_STATUS" != "$CURRENT_STATUS" ]; then
+                log "Network up"
+                LAST_STATUS="$CURRENT_STATUS"
+            fi
+        else
+            CURRENT_STATUS="down"
+            if [ "$LAST_STATUS" != "$CURRENT_STATUS" ]; then
+                log "Network down"
+                LAST_STATUS="$CURRENT_STATUS"
+            fi
+            log "Triggering authentication..."
+            login
         fi
-    else
-        CURRENT_STATUS="down"
-        if [ "$LAST_STATUS" != "$CURRENT_STATUS" ]; then
-            log "Network down"
-            LAST_STATUS="$CURRENT_STATUS"
-        fi
-        log "Triggering authentication..."
-        login
-    fi
-    sleep "$INTERVAL"
-done
+        sleep "$INTERVAL"
+    done
+fi

--- a/shell/test/test-url-encode.sh
+++ b/shell/test/test-url-encode.sh
@@ -1,0 +1,109 @@
+#!/bin/sh
+# 测试：login() 使用 --data-urlencode 正确传递含特殊字符的凭据
+# 分两层：
+#   Layer 1 (静态) — 确认源码使用了 --data-urlencode
+#   Layer 2 (功能) — 注入 mock curl，验证实际调用参数（需要 CSU_TESTING 守卫）
+
+set -eu
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() { printf 'PASS: %s\n' "$1"; PASS_COUNT=$((PASS_COUNT + 1)); }
+fail() { printf 'FAIL: %s\n  期望: %s\n' "$1" "$2"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+
+# ── Layer 1: 静态检查 ─────────────────────────────────────────────────────────
+
+check_urlencode_flag() {
+    label="$1"
+    script="$2"
+
+    if grep -qF -- '--data-urlencode "user_account=' "$script" && \
+       grep -qF -- '--data-urlencode "user_password=' "$script"; then
+        pass "$label: 使用 --data-urlencode 传递凭据"
+    else
+        fail "$label: 应使用 --data-urlencode 传递凭据" "--data-urlencode flag missing in login()"
+    fi
+
+    # 反向：确认裸 -d 已不存在
+    if grep -qF -- '-d "user_account=' "$script" || \
+       grep -qF -- '-d "user_password=' "$script"; then
+        fail "$label: 不应使用裸 -d 传递凭据" "found raw -d parameter"
+    else
+        pass "$label: 已无裸 -d 参数"
+    fi
+}
+
+check_urlencode_flag "shell/common/csu-autoauth.sh" "$REPO_ROOT/shell/common/csu-autoauth.sh"
+check_urlencode_flag "openwrt/csu-autoauth.sh"      "$REPO_ROOT/openwrt/csu-autoauth.sh"
+
+# ── Layer 2: 功能测试（需要 CSU_TESTING 守卫） ────────────────────────────────
+
+run_functional_test() {
+    label="$1"
+    script="$2"
+
+    tmpdir=$(mktemp -d)
+    # shellcheck disable=SC2064
+    trap "rm -rf '$tmpdir'" EXIT
+
+    mock_curl="$tmpdir/curl"
+    args_log="$tmpdir/curl_args"
+
+    cat > "$mock_curl" << 'MOCK'
+#!/bin/sh
+printf '%s\n' "$@" > "$CURL_ARGS_FILE"
+exit 0
+MOCK
+    chmod +x "$mock_curl"
+
+    printf 'USERNAME="20230001"\nPASSWORD="p@ss&w=rd+!"\nTYPE="1"\nINTERVAL="10"\n' \
+        > "$tmpdir/config.conf"
+
+    wrapper="$tmpdir/runner.sh"
+    printf '. "%s"\nlogin\n' "$script" > "$wrapper"
+
+    # 通过后台+sleep强制超时（兼容无 timeout 命令的 macOS）
+    (
+        DATA_DIR="$tmpdir" \
+        LOG_FILE="$tmpdir/test.log" \
+        CONFIG_FILE="$tmpdir/config.conf" \
+        CURL_ARGS_FILE="$args_log" \
+        CSU_TESTING=1 \
+        PATH="$tmpdir:$PATH" \
+        sh "$wrapper" > "$tmpdir/out.log" 2>&1 &
+        WRAPPER_PID=$!
+        sleep 3
+        kill "$WRAPPER_PID" 2>/dev/null || true
+        wait "$WRAPPER_PID" 2>/dev/null || true
+    )
+
+    if [ ! -f "$args_log" ]; then
+        fail "$label 功能测试: mock curl 未被调用（缺少 CSU_TESTING 守卫？）" "curl not invoked"
+        trap - EXIT; rm -rf "$tmpdir"
+        return
+    fi
+
+    if grep -qF -- '--data-urlencode' "$args_log"; then
+        pass "$label 功能测试: curl 收到 --data-urlencode 参数"
+    else
+        fail "$label 功能测试: curl 未收到 --data-urlencode" "$(cat "$args_log")"
+    fi
+
+    trap - EXIT
+    rm -rf "$tmpdir"
+}
+
+run_functional_test "shell/common/csu-autoauth.sh" "$REPO_ROOT/shell/common/csu-autoauth.sh"
+# openwrt 依赖 /lib/functions.sh（OpenWrt 专属），非 OpenWrt 环境跳过功能测试
+if [ -f /lib/functions.sh ]; then
+    run_functional_test "openwrt/csu-autoauth.sh" "$REPO_ROOT/openwrt/csu-autoauth.sh"
+else
+    printf 'SKIP: openwrt/csu-autoauth.sh 功能测试（非 OpenWrt 环境）\n'
+fi
+
+# ── 汇总 ──────────────────────────────────────────────────────────────────────
+
+printf '\n%d passed, %d failed\n' "$PASS_COUNT" "$FAIL_COUNT"
+[ "$FAIL_COUNT" -eq 0 ] || exit 1


### PR DESCRIPTION
## 修复三处影响日常使用的缺陷：                                                                     

1. **认证结果不可见**：无论登录成功还是密码错误，日志均显示 `Login response: ...` 原始文本，用户无法快速判断认证是否真正成功

  2. **含特殊字符的密码静默失败**：Shell / OpenWrt 版本的 `login()` 使用裸 `-d` 传递凭据，密码含 `&`、`=`、`+` 等字符时 curl 会截断参数，导致认证静默失败，用户只能看到网络反复掉线。                                              

  3. **日志文件无限增长**：Node.js 版本作为守护进程长期运行时日志只追加不轮转，在稳定运行的机器上会持续占用磁盘空间

  ## 改动                                                                                        

  - **nodejs/index.js**：新增 `parseLoginResponse`，解析 ePortal JSON 响应（`result` 字段），日志改为 `Login successful` /`Login failed: <msg>`，密码错误等永久性失败现在有明确提示                                      

  - **nodejs/index.js**：新增 `rotateLogIfNeeded`，日志超 5 MB 时自动轮转为 `.1` 文件

  - **shell/common/csu-autoauth.sh**、**openwrt/csu-autoauth.sh**：`login()` 中 `-d` 改为      

     `--data-urlencode`，修复特殊字符密码被截断的问题

## 测试

 ```sh
 cd nodejs && node --test test/*.test.js  # 11 个用例
 sh shell/test/test-url-encode.sh     # Shell 静态检查 + mock curl 验证
 ```

## 兼容性：

全部改动向后兼容，无配置项变更